### PR TITLE
fixed 'open reporters notebook' link

### DIFF
--- a/play-local/index.html
+++ b/play-local/index.html
@@ -48,7 +48,7 @@ published: true
     <h1>Games on SeattleWiki</h1>
     <p>Looking for a guide to all things "games in Seattle"?</p> 
     <p><b><a href="http://seattlewiki.net/games" target="_blank">Go look at SeattleWiki.net/Games.</a></b></p>
-    <p>As we research the games being made in Seattle, we use SeattleWiki as a kind of <a href="http://seattle.io/2013/08/14/seattlewiki/">"open reporter's notebook"</a>.</p>
+    <p>As we research the games being made in Seattle, we use SeattleWiki as a kind of <a href="http://www.seattle.io/posts/using-seattlewiki-net-as-our-open-reporter-s-notebook-for-news">"open reporter's notebook"</a>.</p>
     <p>You can follow along with new info, and even add info about your own games or games made in Seattle that you know about by visiting <a href="http://seattlewiki.net/games" target="_blank">seattlewiki.net/games</a> and editing that page!</p>
   </section>
 


### PR DESCRIPTION
changed from `http://www.seattle.io/2013/08/14/seattlewiki/'; which 404's.
